### PR TITLE
add multiple conditions to Gates

### DIFF
--- a/Assets/Scenes/DonTestScenes/TestLevel01.unity
+++ b/Assets/Scenes/DonTestScenes/TestLevel01.unity
@@ -12329,6 +12329,10 @@ PrefabInstance:
       propertyPath: openConditions.Array.data[0].boolValue
       value: 
       objectReference: {fileID: 11400000, guid: bc635a4e69c1341f1b059283e1e14fed, type: 2}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.data[1].boolValue
+      value: 
+      objectReference: {fileID: 11400000, guid: e8ffdad2f429440789ba1a7d3bfcfbdf, type: 2}
     - target: {fileID: 8677064692514345885, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
       propertyPath: m_Name
       value: Gate

--- a/Assets/Scenes/DonTestScenes/TestLevel01.unity
+++ b/Assets/Scenes/DonTestScenes/TestLevel01.unity
@@ -273,10 +273,10 @@ MonoBehaviour:
     m_SceneAsset: {fileID: 102900000, guid: 871122d253d3b4284923be0bbda6f90c, type: 3}
     m_IsDirty: 0
     m_ScenePath: Assets/Scenes/DonTestScenes/TestLevel02.unity
-  spawnPoint: {fileID: 1116034723}
-  collider: {fileID: 235550592}
   transitionType: 1
   slideTransitionDuration: {fileID: 11400000, guid: f344c4a5a8f9d4b0fa9e71abc5b2f096, type: 2}
+  spawnPoint: {fileID: 1116034723}
+  collider: {fileID: 235550592}
 --- !u!61 &235550592
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -4915,10 +4915,10 @@ MonoBehaviour:
     m_SceneAsset: {fileID: 102900000, guid: 871122d253d3b4284923be0bbda6f90c, type: 3}
     m_IsDirty: 0
     m_ScenePath: Assets/Scenes/DonTestScenes/TestLevel02.unity
-  spawnPoint: {fileID: 1807514867}
-  collider: {fileID: 863817364}
   transitionType: 1
   slideTransitionDuration: {fileID: 11400000, guid: f344c4a5a8f9d4b0fa9e71abc5b2f096, type: 2}
+  spawnPoint: {fileID: 1807514867}
+  collider: {fileID: 863817364}
 --- !u!50 &863817363
 Rigidbody2D:
   serializedVersion: 4
@@ -11984,10 +11984,10 @@ MonoBehaviour:
     m_SceneAsset: {fileID: 102900000, guid: 750d6e3617ddc4347a646988e8f9e7d5, type: 3}
     m_IsDirty: 0
     m_ScenePath: Assets/Scenes/DonTestScenes/TestLevel03.unity
-  spawnPoint: {fileID: 3693175747274329870}
-  collider: {fileID: 3693175746006658605}
   transitionType: 1
   slideTransitionDuration: {fileID: 11400000, guid: f344c4a5a8f9d4b0fa9e71abc5b2f096, type: 2}
+  spawnPoint: {fileID: 3693175747274329870}
+  collider: {fileID: 3693175746006658605}
 --- !u!4 &3693175746006658771
 Transform:
   m_ObjectHideFlags: 0
@@ -12319,6 +12319,14 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
       propertyPath: didHitSwitch
+      value: 
+      objectReference: {fileID: 11400000, guid: bc635a4e69c1341f1b059283e1e14fed, type: 2}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.data[0].boolValue
       value: 
       objectReference: {fileID: 11400000, guid: bc635a4e69c1341f1b059283e1e14fed, type: 2}
     - target: {fileID: 8677064692514345885, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}

--- a/Assets/Scenes/DonTestScenes/TestLevel02.unity
+++ b/Assets/Scenes/DonTestScenes/TestLevel02.unity
@@ -861,6 +861,14 @@ PrefabInstance:
       propertyPath: didHitSwitch
       value: 
       objectReference: {fileID: 11400000, guid: bc635a4e69c1341f1b059283e1e14fed, type: 2}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.data[0].boolValue
+      value: 
+      objectReference: {fileID: 11400000, guid: bc635a4e69c1341f1b059283e1e14fed, type: 2}
     - target: {fileID: 8677064692514345885, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
       propertyPath: m_Name
       value: Gate

--- a/Assets/Scenes/DonTestScenes/TestLevel03.unity
+++ b/Assets/Scenes/DonTestScenes/TestLevel03.unity
@@ -4590,6 +4590,14 @@ PrefabInstance:
       propertyPath: didHitSwitch
       value: 
       objectReference: {fileID: 11400000, guid: bc635a4e69c1341f1b059283e1e14fed, type: 2}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.data[0].boolValue
+      value: 
+      objectReference: {fileID: 11400000, guid: bc635a4e69c1341f1b059283e1e14fed, type: 2}
     - target: {fileID: 8677064692514345885, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
       propertyPath: m_Name
       value: GateWest
@@ -5146,6 +5154,14 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
       propertyPath: didHitSwitch
+      value: 
+      objectReference: {fileID: 11400000, guid: bc635a4e69c1341f1b059283e1e14fed, type: 2}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.data[0].boolValue
       value: 
       objectReference: {fileID: 11400000, guid: bc635a4e69c1341f1b059283e1e14fed, type: 2}
     - target: {fileID: 8677064692514345885, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
@@ -13487,6 +13503,18 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
       propertyPath: didHitSwitch
+      value: 
+      objectReference: {fileID: 11400000, guid: 4ce39da9613854e259db57038c09cf9e, type: 2}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.data[0].invert
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677064692514345824, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}
+      propertyPath: openConditions.Array.data[0].boolValue
       value: 
       objectReference: {fileID: 11400000, guid: 4ce39da9613854e259db57038c09cf9e, type: 2}
     - target: {fileID: 8677064692514345885, guid: a2d70c1c22a024d0c8c7297ffb45aebc, type: 3}

--- a/Assets/Scripts/FieldOfView/FieldOfView.cs
+++ b/Assets/Scripts/FieldOfView/FieldOfView.cs
@@ -81,7 +81,7 @@ public class FieldOfView : MonoBehaviour
         {
             yield return new WaitForSeconds(delayBetweenRaycasts);
             FindVisibleTargets();
-            if (isTriggered) didMotionSensorTrigger.value = true;
+            didMotionSensorTrigger.value = isTriggered;
         }
     }
 

--- a/Assets/Scripts/FieldOfView/FieldOfView.cs
+++ b/Assets/Scripts/FieldOfView/FieldOfView.cs
@@ -18,6 +18,10 @@ public class FieldOfView : MonoBehaviour
 
     [SerializeField] bool debug = false;
 
+    [Space]
+    [Space]
+
+    [SerializeField] bool canUntrigger = true;
     [SerializeField][Range(0, 50)] float viewRadius = 10f;
     [SerializeField][Range(0, 360)] float viewAngle = 30f;
     [SerializeField] Color activeColor = Color.yellow;
@@ -81,7 +85,14 @@ public class FieldOfView : MonoBehaviour
         {
             yield return new WaitForSeconds(delayBetweenRaycasts);
             FindVisibleTargets();
-            didMotionSensorTrigger.value = isTriggered;
+            if (canUntrigger)
+            {
+                didMotionSensorTrigger.value = isTriggered;
+            }
+            else
+            {
+                if (isTriggered) didMotionSensorTrigger.value = true;
+            }
         }
     }
 

--- a/Assets/Scripts/SOFramework/BoolCondition.cs
+++ b/Assets/Scripts/SOFramework/BoolCondition.cs
@@ -4,24 +4,25 @@ using UnityEngine;
 namespace CyberneticStudios.SOFramework
 {
 
-    [CreateAssetMenu(menuName = "Conditions/Bool Condition")]
-    public class BoolCondition : ScriptableObject
+    [Serializable]
+    public class BoolCondition
     {
-        public enum ConditionType
-        {
-            IS_TRUE,
-            IS_FALSE
-        }
-
         [SerializeField] BoolVariable boolValue;
-        [SerializeField] ConditionType conditionType;
+        [SerializeField] bool invert;
 
         public bool value => GetValue();
 
+        public event System.Action<bool> OnChanged
+        {
+            // see: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/add
+            add { boolValue.OnChanged += value; }
+            remove { boolValue.OnChanged -= value; }
+        }
+
         bool GetValue()
         {
-            if (conditionType == ConditionType.IS_TRUE) return boolValue.value;
-            return !boolValue.value;
+            if (invert) return !boolValue.value;
+            return boolValue.value;
         }
     }
 }

--- a/Assets/Scripts/SOFramework/Editor.meta
+++ b/Assets/Scripts/SOFramework/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 98352a1cb5d864777b7c5a09885a0445
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SOFramework/Editor/BoolVariableEditor.cs
+++ b/Assets/Scripts/SOFramework/Editor/BoolVariableEditor.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using UnityEditor;
+
+using CyberneticStudios.SOFramework;
+
+[CustomEditor(typeof(BoolVariable))]
+public class BoolVariableEditor : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        base.OnInspectorGUI();
+
+        var script = (BoolVariable)target;
+
+        GUILayout.BeginVertical();
+
+        GUILayout.Space(40);
+
+        GUILayout.Label("Press the button below to send OnChanged events to all listeners");
+
+        if (GUILayout.Button("Invoke Callbacks", GUILayout.Height(40)))
+        {
+            script.InvokeCallbacks();
+        }
+
+        GUILayout.EndVertical();
+    }
+}

--- a/Assets/Scripts/SOFramework/Editor/BoolVariableEditor.cs.meta
+++ b/Assets/Scripts/SOFramework/Editor/BoolVariableEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82eac34efabaf4de28cee5e40f11374d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SOFramework/Variable.cs
+++ b/Assets/Scripts/SOFramework/Variable.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace CyberneticStudios.SOFramework
 {
-    public abstract class Variable<T> : BaseVariable, ISerializationCallbackReceiver
+    public abstract class Variable<T> : BaseVariable
     {
 
 #if UNITY_EDITOR
@@ -10,7 +10,7 @@ namespace CyberneticStudios.SOFramework
         public string DeveloperDescription = "";
 #endif
 
-        public System.Action<T> OnChanged;
+        public event System.Action<T> OnChanged;
 
         [SerializeField] private T _initialValue;
         [SerializeField] private T _value;
@@ -34,11 +34,9 @@ namespace CyberneticStudios.SOFramework
             value = _initialValue;
         }
 
-        public void OnAfterDeserialize()
+        public void InvokeCallbacks()
         {
-            OnChanged?.Invoke(_value);
+            OnChanged?.Invoke(value);
         }
-
-        public void OnBeforeSerialize() { }
     }
 }


### PR DESCRIPTION
This PR allows us to add multiple conditions to check in order to open a gate. Each condition can also be inverted (true=false).

For example:
- sensor sees player (true)
- door only opens if sensor does NOT see player

<img width="451" alt="image" src="https://user-images.githubusercontent.com/5880655/219530716-d3b4149d-832c-4cec-bf2a-0509248d7526.png">
