### PR TITLE
fix player possession state

### DIFF
--- a/Assets/Plugins/FMOD/platforms/html5/lib/libfmodstudiounityplugin.bc.meta
+++ b/Assets/Plugins/FMOD/platforms/html5/lib/libfmodstudiounityplugin.bc.meta
@@ -1,21 +1,30 @@
 fileFormatVersion: 2
 guid: 254f6ee9df4d3024d9c550104ea5feaf
-timeCreated: 1518408468
-licenseType: Free
 PluginImporter:
-  serializedVersion: 1
+  externalObjects: {}
+  serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
-    Any:
+  - first:
+      Any: 
+    second:
       enabled: 0
       settings: {}
-    Editor:
+  - first:
+      Editor: Editor
+    second:
       enabled: 0
       settings:
         DefaultValueInitialized: true
-    WebGL:
+  - first:
+      WebGL: WebGL
+    second:
       enabled: 1
       settings: {}
   userData: 

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -168,6 +168,8 @@ MonoBehaviour:
   groundCheck: {fileID: 2806582366043827935}
   ceilingCheck: {fileID: 2806582367019756474}
   crouchCollider: {fileID: 0}
+  enemyAI: {fileID: 0}
+  isFacingRight: 1
   OnLandEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -243,6 +245,7 @@ MonoBehaviour:
   animator: {fileID: 0}
   defaultAnimator: {fileID: 0}
   movement: {fileID: 11400000, guid: 32773d3c345b6404d88ae00620802692, type: 2}
+  moveSound: {fileID: 0}
 --- !u!114 &2806582366043827920
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -340,6 +343,8 @@ MonoBehaviour:
   inputManager: {fileID: 2806582366043827934}
   hitbox: {fileID: 2806582366932157628}
   attackData: {fileID: 0}
+  defaultAttack: {fileID: 0}
+  possessAttack: {fileID: 0}
   defaultMeleeAttack: {fileID: 11400000, guid: e1d19feb4711f4d4ebde7d1bb8164620, type: 2}
   defaultProjectileAttack: {fileID: 11400000, guid: bf54fb62e11806342b1fb295eb2ac1a9, type: 2}
   projectileOrigin: {fileID: 2806582365070056088}
@@ -372,7 +377,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isEnemy: 0
   animator: {fileID: 2806582366043827923}
-  defaultAnimator: {fileID: 0}
+  healthyAnimator: {fileID: 0}
   hurtAnimator: {fileID: 0}
   perilAnimator: {fileID: 0}
   resources: {fileID: 2806582366043827925}
@@ -383,6 +388,15 @@ MonoBehaviour:
   hurtThreshold: 7
   hurtSound: {fileID: 0}
   deathSound: {fileID: 0}
+  possessionManager: {fileID: 0}
+  enemySlimePossessionAnimator: {fileID: 0}
+  healthySlimePossessionAnimator: {fileID: 0}
+  hurtSlimePossessionAnimator: {fileID: 0}
+  perilSlimePossessionAnimator: {fileID: 0}
+  attack: {fileID: 0}
+  healthySlimeProjectileAttackData: {fileID: 0}
+  hurtSlimeProjectileAttackData: {fileID: 0}
+  perilSlimeProjectileAttackData: {fileID: 0}
 --- !u!114 &4127488969785509700
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -395,6 +409,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5ffaae510d1e741308e5c1ccbbaf8a8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isPlayerPossessing: {fileID: 11400000, guid: cf0648d02273744cca9a37866585f057, type: 2}
 --- !u!1 &2806582366932157626
 GameObject:
   m_ObjectHideFlags: 0
@@ -441,11 +456,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4ea566673b88c74f925f458d07d7f07, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  disableInEditor: 0
+  disableInProdBuild: 0
+  debugInPlayMode: 0
   attackData: {fileID: 0}
   isEnemyHitbox: 0
   hitOnce: 0
+  targetLayers:
+    serializedVersion: 2
+    m_Bits: 0
   sourcePossessionManager: {fileID: 0}
+  hitSound: {fileID: 0}
 --- !u!212 &2806582366932157630
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player/SlimePlayer.prefab
+++ b/Assets/Prefabs/Player/SlimePlayer.prefab
@@ -627,6 +627,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5ffaae510d1e741308e5c1ccbbaf8a8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isPlayerPossessing: {fileID: 11400000, guid: cf0648d02273744cca9a37866585f057, type: 2}
 --- !u!114 &7218248250105349990
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/DonTestScenes/TestLevel01.unity
+++ b/Assets/Scenes/DonTestScenes/TestLevel01.unity
@@ -589,6 +589,7 @@ MonoBehaviour:
   conditionToEnable:
     boolValue: {fileID: 11400000, guid: 57c5f0edd75e24fe48b533c8b1bf6264, type: 2}
     invert: 1
+  onlyCheckAtRoomLoad: 0
 --- !u!4 &240483214
 Transform:
   m_ObjectHideFlags: 0
@@ -1838,6 +1839,7 @@ MonoBehaviour:
   conditionToEnable:
     boolValue: {fileID: 11400000, guid: 57c5f0edd75e24fe48b533c8b1bf6264, type: 2}
     invert: 0
+  onlyCheckAtRoomLoad: 0
 --- !u!1 &621280458
 GameObject:
   m_ObjectHideFlags: 0
@@ -4303,6 +4305,36 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 1073741825
+  - first: {x: 4, y: 0, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 3
+      m_TileSpriteIndex: 8
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741826
+  - first: {x: 3, y: 1, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 3
+      m_TileSpriteIndex: 3
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741826
+  - first: {x: 4, y: 1, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 3
+      m_TileSpriteIndex: 4
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741826
   - first: {x: -24, y: 2, z: 0}
     second:
       serializedVersion: 2
@@ -4343,6 +4375,36 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 1073741825
+  - first: {x: 2, y: 2, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 3
+      m_TileSpriteIndex: 7
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741826
+  - first: {x: 3, y: 2, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 3
+      m_TileSpriteIndex: 5
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741826
+  - first: {x: 4, y: 2, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 3
+      m_TileSpriteIndex: 6
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741826
   - first: {x: 22, y: 2, z: 0}
     second:
       serializedVersion: 2
@@ -6231,6 +6293,8 @@ Tilemap:
     m_Data: {fileID: 11400000, guid: 4a1213b1276534c81af43726f7f0e804, type: 2}
   - m_RefCount: 26
     m_Data: {fileID: 11400000, guid: 1b2750c157afa47ddaf16c1d662c5094, type: 2}
+  - m_RefCount: 6
+    m_Data: {fileID: 11400000, guid: 0b20d3f506eee4e12bf886e000a57ae7, type: 2}
   m_TileSpriteArray:
   - m_RefCount: 28
     m_Data: {fileID: -6936392015693436163, guid: b2a11c94fc6b24414aaf60717f07f5c6, type: 3}
@@ -6238,8 +6302,20 @@ Tilemap:
     m_Data: {fileID: -5576309508184155519, guid: 3860de62b227a4b5dada75ef51a93157, type: 3}
   - m_RefCount: 26
     m_Data: {fileID: -5630681945600182063, guid: b4b55b9f1fb204431ade37b30dcb6102, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -751513039, guid: 209188f2ca030b41497b09e6b3bee9f2, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -1275116085, guid: 209188f2ca030b41497b09e6b3bee9f2, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -1835122944, guid: 209188f2ca030b41497b09e6b3bee9f2, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -1905100366, guid: 209188f2ca030b41497b09e6b3bee9f2, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -1658067448, guid: 209188f2ca030b41497b09e6b3bee9f2, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 813030128, guid: 209188f2ca030b41497b09e6b3bee9f2, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 380
+  - m_RefCount: 386
     m_Data:
       e00: 1
       e01: 0
@@ -6258,7 +6334,7 @@ Tilemap:
       e32: 0
       e33: 1
   m_TileColorArray:
-  - m_RefCount: 380
+  - m_RefCount: 386
     m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
@@ -6298,7 +6374,7 @@ CompositeCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  m_GeometryType: 0
+  m_GeometryType: 1
   m_GenerationType: 0
   m_EdgeRadius: 0.01
   m_ColliderPaths:
@@ -6384,6 +6460,22 @@ CompositeCollider2D:
         Y: 60000000
       - X: -280000000
         Y: 60000000
+    - - X: 100000000
+        Y: 60000000
+      - X: 40000000
+        Y: 60000000
+      - X: 40000000
+        Y: 40000000
+      - X: 60000000
+        Y: 40000000
+      - X: 60000000
+        Y: 20000000
+      - X: 80000000
+        Y: 20000000
+      - X: 80000000
+        Y: 0
+      - X: 100000000
+        Y: 0
     - - X: -160000000
         Y: 20000000
       - X: -180000000
@@ -6456,12 +6548,6 @@ CompositeCollider2D:
       - {x: 28.000296, y: 20}
       - {x: 44, y: 19.999708}
       - {x: 44.000294, y: 4}
-    - - {x: -44.000294, y: 4}
-      - {x: -43.999706, y: 20}
-      - {x: -28, y: 20.000294}
-      - {x: -28.000296, y: 24}
-      - {x: -48, y: 23.999708}
-      - {x: -47.999706, y: 4}
     - - {x: 1.9997072, y: 4}
       - {x: 2.000293, y: 8}
       - {x: 8, y: 8.000293}
@@ -6482,14 +6568,28 @@ CompositeCollider2D:
       - {x: -7.999707, y: 8}
       - {x: -2, y: 7.999707}
       - {x: -1.9997072, y: 4}
-    - - {x: -28.000296, y: 6}
-      - {x: -28.000296, y: 8}
-      - {x: -30, y: 7.999707}
-      - {x: -29.999706, y: 6}
+    - - {x: -44.000294, y: 4}
+      - {x: -43.999706, y: 20}
+      - {x: -28, y: 20.000294}
+      - {x: -28.000296, y: 24}
+      - {x: -48, y: 23.999708}
+      - {x: -47.999706, y: 4}
     - - {x: -16.000294, y: 6}
       - {x: -16.000294, y: 8}
       - {x: -18, y: 7.999707}
       - {x: -17.999708, y: 6}
+    - - {x: -28.000296, y: 6}
+      - {x: -28.000296, y: 8}
+      - {x: -30, y: 7.999707}
+      - {x: -29.999706, y: 6}
+    - - {x: 9.999707, y: 0}
+      - {x: 9.999707, y: 6}
+      - {x: 4, y: 5.999707}
+      - {x: 4.000293, y: 4}
+      - {x: 6, y: 3.9997072}
+      - {x: 6.000293, y: 2}
+      - {x: 8, y: 1.999707}
+      - {x: 8.000293, y: 0}
     - - {x: -16.000294, y: 0}
       - {x: -16.000294, y: 2}
       - {x: -18, y: 1.9997072}
@@ -13729,6 +13829,7 @@ MonoBehaviour:
   conditionToEnable:
     boolValue: {fileID: 11400000, guid: 57c5f0edd75e24fe48b533c8b1bf6264, type: 2}
     invert: 0
+  onlyCheckAtRoomLoad: 0
 --- !u!4 &1516536352
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/PlayerMain.cs
+++ b/Assets/Scripts/Player/PlayerMain.cs
@@ -1,11 +1,13 @@
 using UnityEngine;
 
 using MapGen;
+using CyberneticStudios.SOFramework;
 
 public class PlayerMain : MonoBehaviour
 {
-    Rigidbody2D body;
+    [SerializeField] BoolVariable isPlayerPossessing;
 
+    Rigidbody2D body;
     PlayerCombat playerCombat;
 
     public void SetKinematic()
@@ -22,6 +24,11 @@ public class PlayerMain : MonoBehaviour
     {
         body = GetComponent<Rigidbody2D>();
         playerCombat = GetComponent<PlayerCombat>();
+    }
+
+    void Start()
+    {
+        if (GetComponent<PossessionManager>() == null) isPlayerPossessing.value = false;
     }
 
     void Update()

--- a/Assets/Scripts/Player/PlayerMain.cs.meta
+++ b/Assets/Scripts/Player/PlayerMain.cs.meta
@@ -3,7 +3,8 @@ guid: 5ffaae510d1e741308e5c1ccbbaf8a8c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - isPlayerPossessing: {fileID: 11400000, guid: cf0648d02273744cca9a37866585f057, type: 2}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 


### PR DESCRIPTION
Ensure that the `IsPlayerPossessingSomething` BoolVariable is set back to `false` upon player respawn.

Background:

I found a bug where it's possible that the player can die while possessing the enemy, and the IsPlayerPossessingAnything BoolVariable doesn't get set back to false, rendering the player unable to go through vents. It's difficult to repro but definitely possible. Happened when a friend of mine was playing the game
