### PR TITLE
Adjusted several enemies to feel more balanced

### DIFF
--- a/Assets/Animations/Characters/Slime/PossessionIndicator.meta
+++ b/Assets/Animations/Characters/Slime/PossessionIndicator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59bdea46f4fe7244cb99c2a5f8598e20
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Characters/Slime/PossessionIndicator/PossessionIndicatorAnimator.controller
+++ b/Assets/Animations/Characters/Slime/PossessionIndicator/PossessionIndicatorAnimator.controller
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-8513608494505227148
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PossessionLineAnimation
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 76d39ba6c51b57a4bbbea35ab8f4c6b0, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &-8347212643508920602
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -8513608494505227148}
+    m_Position: {x: 320, y: 70, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 630, y: 60, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -8513608494505227148}
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PossessionIndicatorAnimator
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -8347212643508920602}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}

--- a/Assets/Animations/Characters/Slime/PossessionIndicator/PossessionIndicatorAnimator.controller.meta
+++ b/Assets/Animations/Characters/Slime/PossessionIndicator/PossessionIndicatorAnimator.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d7f1e37334f4b1e4ca13cc32a9fc6296
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Characters/Slime/PossessionIndicator/PossessionLineAnimation.anim
+++ b/Assets/Animations/Characters/Slime/PossessionIndicator/PossessionLineAnimation.anim
@@ -1,0 +1,446 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PossessionLineAnimation
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.16666667
+        value: {x: 0.333, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: LineSegment1
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0.333, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.16666667
+        value: {x: 0.667, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: LineSegment2
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0.667, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.16666667
+        value: {x: 1, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: LineSegment3
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_IsActive
+    path: LineSegment4
+    classID: 1
+    script: {fileID: 0}
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 2662801953
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+    - serializedVersion: 2
+      path: 129921947
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+    - serializedVersion: 2
+      path: 1891189517
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+    - serializedVersion: 2
+      path: 4007515822
+      attribute: 2086281974
+      script: {fileID: 0}
+      typeID: 1
+      customType: 0
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.16666667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_IsActive
+    path: LineSegment4
+    classID: 1
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 0.333
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: LineSegment1
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: LineSegment1
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: LineSegment1
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.333
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 0.667
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: LineSegment2
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: LineSegment2
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: LineSegment2
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.667
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: LineSegment3
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: LineSegment3
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: LineSegment3
+    classID: 4
+    script: {fileID: 0}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Characters/Slime/PossessionIndicator/PossessionLineAnimation.anim.meta
+++ b/Assets/Animations/Characters/Slime/PossessionIndicator/PossessionLineAnimation.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 76d39ba6c51b57a4bbbea35ab8f4c6b0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Characters/Slime/Slime Healthy Animations/SlimeHealthyAnimator.controller
+++ b/Assets/Animations/Characters/Slime/Slime Healthy Animations/SlimeHealthyAnimator.controller
@@ -553,49 +553,49 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: ProjectileAttack
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Hurt
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Jump
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Fall
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Land
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isMoving
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isGrounded
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Animations/Characters/Slime/Slime Healthy Animations/SlimeHealthyMelee.anim
+++ b/Assets/Animations/Characters/Slime/Slime Healthy Animations/SlimeHealthyMelee.anim
@@ -38,11 +38,29 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0
         outWeight: 0
+      - serializedVersion: 3
+        time: 0.25
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 0.4166667
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_IsActive
-    path: Hitbox
+    path: PossessionHitbox
     classID: 1
     script: {fileID: 0}
   m_PPtrCurves:
@@ -69,7 +87,7 @@ AnimationClip:
   m_ClipBindingConstant:
     genericBindings:
     - serializedVersion: 2
-      path: 3579746941
+      path: 792009572
       attribute: 2086281974
       script: {fileID: 0}
       typeID: 1
@@ -130,11 +148,29 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0
         outWeight: 0
+      - serializedVersion: 3
+        time: 0.25
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 0.4166667
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_IsActive
-    path: Hitbox
+    path: PossessionHitbox
     classID: 1
     script: {fileID: 0}
   m_EulerEditorCurves: []

--- a/Assets/Animations/Characters/Slime/Slime Hurt Animations/SlimeHurtMelee.anim
+++ b/Assets/Animations/Characters/Slime/Slime Hurt Animations/SlimeHurtMelee.anim
@@ -47,11 +47,20 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0
         outWeight: 0
+      - serializedVersion: 3
+        time: 0.4166667
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_IsActive
-    path: Hitbox
+    path: PossessionHitbox
     classID: 1
     script: {fileID: 0}
   m_PPtrCurves:
@@ -78,7 +87,7 @@ AnimationClip:
   m_ClipBindingConstant:
     genericBindings:
     - serializedVersion: 2
-      path: 3579746941
+      path: 792009572
       attribute: 2086281974
       script: {fileID: 0}
       typeID: 1
@@ -148,11 +157,20 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0
         outWeight: 0
+      - serializedVersion: 3
+        time: 0.4166667
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_IsActive
-    path: Hitbox
+    path: PossessionHitbox
     classID: 1
     script: {fileID: 0}
   m_EulerEditorCurves: []

--- a/Assets/Animations/Characters/Slime/Slime Peril Animations/SlimePerilMelee.anim
+++ b/Assets/Animations/Characters/Slime/Slime Peril Animations/SlimePerilMelee.anim
@@ -47,11 +47,20 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0
         outWeight: 0
+      - serializedVersion: 3
+        time: 0.4166667
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_IsActive
-    path: Hitbox
+    path: PossessionHitbox
     classID: 1
     script: {fileID: 0}
   m_PPtrCurves:
@@ -78,7 +87,7 @@ AnimationClip:
   m_ClipBindingConstant:
     genericBindings:
     - serializedVersion: 2
-      path: 3579746941
+      path: 792009572
       attribute: 2086281974
       script: {fileID: 0}
       typeID: 1
@@ -148,11 +157,20 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0
         outWeight: 0
+      - serializedVersion: 3
+        time: 0.4166667
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_IsActive
-    path: Hitbox
+    path: PossessionHitbox
     classID: 1
     script: {fileID: 0}
   m_EulerEditorCurves: []

--- a/Assets/Animations/Enemies/Spider/SpiderFire.anim
+++ b/Assets/Animations/Enemies/Spider/SpiderFire.anim
@@ -16,62 +16,7 @@ AnimationClip:
   m_EulerCurves: []
   m_PositionCurves: []
   m_ScaleCurves: []
-  m_FloatCurves:
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 0.083333336
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 0.16666667
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 0.25
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 0.33333334
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_Enabled
-    path: 
-    classID: 58
-    script: {fileID: 0}
+  m_FloatCurves: []
   m_PPtrCurves:
   - curve:
     - time: 0
@@ -125,13 +70,6 @@ AnimationClip:
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
     genericBindings:
-    - serializedVersion: 2
-      path: 0
-      attribute: 3305885265
-      script: {fileID: 0}
-      typeID: 58
-      customType: 0
-      isPPtrCurve: 0
     - serializedVersion: 2
       path: 1235141019
       attribute: 0
@@ -189,62 +127,7 @@ AnimationClip:
     m_KeepOriginalPositionXZ: 0
     m_HeightFromFeet: 0
     m_Mirror: 0
-  m_EditorCurves:
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 0.083333336
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 0.16666667
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 0.25
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 0.33333334
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_Enabled
-    path: 
-    classID: 58
-    script: {fileID: 0}
+  m_EditorCurves: []
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0

--- a/Assets/Prefabs/EnemiesHazardsWeapons/CatEnemyPrefab.prefab
+++ b/Assets/Prefabs/EnemiesHazardsWeapons/CatEnemyPrefab.prefab
@@ -7889,11 +7889,11 @@ PrefabInstance:
     - target: {fileID: 6423778844265691418, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: attackData
       value: 
-      objectReference: {fileID: 11400000, guid: 4b164065165f3374480d5a7724889f55, type: 2}
+      objectReference: {fileID: 11400000, guid: 075898bc2c3a7d34bbb1440cb8caf9f7, type: 2}
     - target: {fileID: 6423778844265691418, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: defaultAttack
       value: 
-      objectReference: {fileID: 11400000, guid: 4b164065165f3374480d5a7724889f55, type: 2}
+      objectReference: {fileID: 11400000, guid: 075898bc2c3a7d34bbb1440cb8caf9f7, type: 2}
     - target: {fileID: 6423778844265691418, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: defaultMeleeAttack
       value: 

--- a/Assets/Prefabs/EnemiesHazardsWeapons/GuardEnemyPrefab.prefab
+++ b/Assets/Prefabs/EnemiesHazardsWeapons/GuardEnemyPrefab.prefab
@@ -130,6 +130,10 @@ PrefabInstance:
       propertyPath: reflexJump
       value: 
       objectReference: {fileID: 1980591411}
+    - target: {fileID: 6423778844265691399, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
+      propertyPath: reflexJumpCollider
+      value: 
+      objectReference: {fileID: 1980591412}
     - target: {fileID: 6423778844265691409, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: m_RootOrder
       value: 0
@@ -210,6 +214,10 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 28cb2e78134e5f64faba57e771a62089, type: 3}
+    - target: {fileID: 8487835381121414874, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
 --- !u!114 &1459318839837618881 stripped

--- a/Assets/Prefabs/EnemiesHazardsWeapons/MechBossMissilePrefab.prefab
+++ b/Assets/Prefabs/EnemiesHazardsWeapons/MechBossMissilePrefab.prefab
@@ -106,13 +106,15 @@ MonoBehaviour:
   rb: {fileID: 6624971411110971916}
   riseVelocity: 10
   fallVelocity: 20
-  fallHeight: 15
+  fallHeight: 10
   missileFallSound: {fileID: 2013066647839653474}
   explosionPrefab: {fileID: 2489834823405233076, guid: 9498151a21c22403f9b4fa876fbcc0e0, type: 3}
   detonationLayerMask:
     serializedVersion: 2
     m_Bits: 137
   explosionOffset: {x: 0, y: -1, z: 0}
+  player: {fileID: 0}
+  playerLocationAtSpawn: {x: 0, y: 0, z: 0}
 --- !u!50 &6624971411110971916
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Prefabs/EnemiesHazardsWeapons/RatEnemyPrefab.prefab
+++ b/Assets/Prefabs/EnemiesHazardsWeapons/RatEnemyPrefab.prefab
@@ -352,7 +352,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3960840469428454059, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 6423778844265691398, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: m_Controller
@@ -419,9 +419,13 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 7617262759156446086}
     - target: {fileID: 6423778844265691418, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
+      propertyPath: defaultAttack
+      value: 
+      objectReference: {fileID: 11400000, guid: cc4a4ac7f5b2b724cb4f5b90a8b1007f, type: 2}
+    - target: {fileID: 6423778844265691418, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: defaultMeleeAttack
       value: 
-      objectReference: {fileID: 11400000, guid: cf21cde720766e34ea46d66506a4c9f4, type: 2}
+      objectReference: {fileID: 11400000, guid: cc4a4ac7f5b2b724cb4f5b90a8b1007f, type: 2}
     - target: {fileID: 6423778844265691423, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: jumpSound
       value: 

--- a/Assets/Prefabs/EnemiesHazardsWeapons/SpiderEnemyFire.prefab
+++ b/Assets/Prefabs/EnemiesHazardsWeapons/SpiderEnemyFire.prefab
@@ -265,8 +265,8 @@ GameObject:
   - component: {fileID: 6624971411110971916}
   - component: {fileID: 1678638503480523690}
   - component: {fileID: 1294727736}
-  - component: {fileID: 8228191669675615902}
   - component: {fileID: 9111220567205382277}
+  - component: {fileID: -8460476769202952724}
   m_Layer: 0
   m_Name: SpiderEnemyFire
   m_TagString: Enemy
@@ -399,28 +399,6 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
---- !u!114 &8228191669675615902
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8368949391819313113}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4ea566673b88c74f925f458d07d7f07, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  disableInProdBuild: 0
-  debugInPlayMode: 0
-  attackData: {fileID: 11400000, guid: 1073039dc11d3ae4ea32eb9ee4036d45, type: 2}
-  isEnemyHitbox: 1
-  hitOnce: 0
-  targetLayers:
-    serializedVersion: 2
-    m_Bits: 1152
-  sourcePossessionManager: {fileID: 0}
-  hitSound: {fileID: 985127869259959668}
 --- !u!61 &9111220567205382277
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -447,6 +425,21 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2.53, y: 2.52}
   m_EdgeRadius: 0
+--- !u!114 &-8460476769202952724
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8368949391819313113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8ba5ecddd11aba449261c84bb496dce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  attackData: {fileID: 11400000, guid: 1073039dc11d3ae4ea32eb9ee4036d45, type: 2}
+  hitboxPrefab: {fileID: 8228191669675615902, guid: 81cef31497f581c4ca848f01e19a09b3, type: 3}
+  sourcePossessionManager: {fileID: 0}
 --- !u!1001 &3709643340462397032
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -504,17 +497,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1281cb150d35c49f9b32a2847f2ecb47, type: 3}
---- !u!114 &985127869259959668 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4526307176611076892, guid: 1281cb150d35c49f9b32a2847f2ecb47, type: 3}
-  m_PrefabInstance: {fileID: 3709643340462397032}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dbe822f54c4bb48a1b6c55dd0534636e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &985127869680470413 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4526307176725340133, guid: 1281cb150d35c49f9b32a2847f2ecb47, type: 3}

--- a/Assets/Prefabs/EnemiesHazardsWeapons/SpiderEnemyFireHitbox.prefab
+++ b/Assets/Prefabs/EnemiesHazardsWeapons/SpiderEnemyFireHitbox.prefab
@@ -9,14 +9,12 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8368949391819313124}
-  - component: {fileID: 8368949391819313127}
-  - component: {fileID: 8368949391819313125}
   - component: {fileID: 6624971411110971916}
   - component: {fileID: 1678638503480523690}
-  - component: {fileID: 1294727736}
-  - component: {fileID: 4667946408233099073}
+  - component: {fileID: 8228191669675615902}
+  - component: {fileID: 9111220567205382277}
   m_Layer: 0
-  m_Name: SpiderEnemyProjectile
+  m_Name: SpiderEnemyFireHitbox
   m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -31,81 +29,13 @@ Transform:
   m_GameObject: {fileID: 8368949391819313113}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -3.86, y: 1.05, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 985127869680470413}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &8368949391819313127
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8368949391819313113}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: d6874501d60190c4aa8f60adcedf2148, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 1
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!58 &8368949391819313125
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8368949391819313113}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 1, y: -0.3}
-  serializedVersion: 2
-  m_Radius: 1.5
 --- !u!50 &6624971411110971916
 Rigidbody2D:
   serializedVersion: 4
@@ -139,28 +69,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9e8f94baa35441348ba366552e25cb33, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  attackData: {fileID: 11400000, guid: e5cae9a7d08b9c046a4c6904ca948f89, type: 2}
---- !u!95 &1294727736
-Animator:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8368949391819313113}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 51cf4e572f2f1424391159e5904fffec, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
---- !u!114 &4667946408233099073
+  attackData: {fileID: 11400000, guid: 1073039dc11d3ae4ea32eb9ee4036d45, type: 2}
+--- !u!114 &8228191669675615902
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -169,21 +79,45 @@ MonoBehaviour:
   m_GameObject: {fileID: 8368949391819313113}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2791c7ad193ae0145be6494e6fa6a25f, type: 3}
+  m_Script: {fileID: 11500000, guid: f4ea566673b88c74f925f458d07d7f07, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   disableInProdBuild: 0
   debugInPlayMode: 0
-  attackData: {fileID: 11400000, guid: e5cae9a7d08b9c046a4c6904ca948f89, type: 2}
+  attackData: {fileID: 11400000, guid: 1073039dc11d3ae4ea32eb9ee4036d45, type: 2}
   isEnemyHitbox: 1
-  hitOnce: 1
+  hitOnce: 0
   targetLayers:
     serializedVersion: 2
     m_Bits: 1152
   sourcePossessionManager: {fileID: 5496291906578540761, guid: ed163339f39479e4d9de9126dbe41c10, type: 3}
   hitSound: {fileID: 985127869259959668}
-  firePrefab: {fileID: -8460476769202952724, guid: 6a6a5eb75c0216f43aab4f8e3d2eaf21, type: 3}
-  spawnAngle: {x: 0, y: 0, z: 90}
+--- !u!61 &9111220567205382277
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8368949391819313113}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2.53, y: 2.52}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2.53, y: 2.52}
+  m_EdgeRadius: 0
 --- !u!1001 &3709643340462397032
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/EnemiesHazardsWeapons/SpiderEnemyFireHitbox.prefab.meta
+++ b/Assets/Prefabs/EnemiesHazardsWeapons/SpiderEnemyFireHitbox.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81cef31497f581c4ca848f01e19a09b3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/EnemiesHazardsWeapons/SpiderEnemyPrefab.prefab
+++ b/Assets/Prefabs/EnemiesHazardsWeapons/SpiderEnemyPrefab.prefab
@@ -130,15 +130,19 @@ PrefabInstance:
     - target: {fileID: 6423778844265691418, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: attackData
       value: 
-      objectReference: {fileID: 11400000, guid: e5cae9a7d08b9c046a4c6904ca948f89, type: 2}
+      objectReference: {fileID: 11400000, guid: c4e96350ee628e147960cdead7503b1c, type: 2}
     - target: {fileID: 6423778844265691418, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: defaultAttack
       value: 
-      objectReference: {fileID: 11400000, guid: e5cae9a7d08b9c046a4c6904ca948f89, type: 2}
+      objectReference: {fileID: 11400000, guid: c4e96350ee628e147960cdead7503b1c, type: 2}
+    - target: {fileID: 6423778844265691418, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
+      propertyPath: projectilePrefab
+      value: 
+      objectReference: {fileID: 8368949391819313113, guid: 08d4fa3cc6fef2643a728ee1fcf45aeb, type: 3}
     - target: {fileID: 6423778844265691418, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: defaultProjectileAttack
       value: 
-      objectReference: {fileID: 11400000, guid: e5cae9a7d08b9c046a4c6904ca948f89, type: 2}
+      objectReference: {fileID: 11400000, guid: c4e96350ee628e147960cdead7503b1c, type: 2}
     - target: {fileID: 6423778845231642115, guid: ad0318c83ccbc354899248ab4f217e14, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1.5

--- a/Assets/Prefabs/Player/SlimePlayer.prefab
+++ b/Assets/Prefabs/Player/SlimePlayer.prefab
@@ -1,5 +1,452 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4616485
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4616486}
+  m_Layer: 11
+  m_Name: StartPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4616486
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4616485}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1436785541}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &156160540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 156160541}
+  - component: {fileID: 156160542}
+  m_Layer: 11
+  m_Name: LineSegment1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &156160541
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 156160540}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1436785541}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &156160542
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 156160540}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 09c51c412c77b2945ac358ed0b2ed42a, type: 3}
+  m_Color: {r: 0, g: 0.5471698, b: 0.056627057, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &474475024
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 474475025}
+  m_Layer: 11
+  m_Name: EndPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &474475025
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 474475024}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1436785541}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &491397503
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 491397504}
+  - component: {fileID: 491397505}
+  m_Layer: 11
+  m_Name: LineSegment2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &491397504
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491397503}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.333, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1436785541}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &491397505
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491397503}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 09c51c412c77b2945ac358ed0b2ed42a, type: 3}
+  m_Color: {r: 0, g: 0.5471698, b: 0.056627057, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &1436785540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1436785541}
+  - component: {fileID: 1436785542}
+  m_Layer: 11
+  m_Name: IndicatorLine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1436785541
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1436785540}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 156160541}
+  - {fileID: 491397504}
+  - {fileID: 1830536922}
+  - {fileID: 4616486}
+  - {fileID: 474475025}
+  m_Father: {fileID: 1715315432}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &1436785542
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1436785540}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: d7f1e37334f4b1e4ca13cc32a9fc6296, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+--- !u!1 &1715315431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1715315432}
+  - component: {fileID: 1715315433}
+  - component: {fileID: 1715315434}
+  m_Layer: 11
+  m_Name: PossessionIndicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1715315432
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1715315431}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1436785541}
+  m_Father: {fileID: 8522799911517438544}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1715315433
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1715315431}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.5, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.3350002, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &1715315434
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1715315431}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d1a896fd6e77b7478f07ff7bf997ec9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  indicatorLine: {fileID: 1436785540}
+  lineStartPoint: {fileID: 4616486}
+  lineEndPoint: {fileID: 474475025}
+  playerMovement: {fileID: 8522799911517438551}
+--- !u!1 &1830536921
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1830536922}
+  - component: {fileID: 1830536923}
+  m_Layer: 11
+  m_Name: LineSegment3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1830536922
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1830536921}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.667, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1436785541}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1830536923
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1830536921}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 09c51c412c77b2945ac358ed0b2ed42a, type: 3}
+  m_Color: {r: 0, g: 0.5471698, b: 0.056627057, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &2008288455391228597
 GameObject:
   m_ObjectHideFlags: 0
@@ -128,8 +575,8 @@ GameObject:
   - component: {fileID: 8522799911296395313}
   - component: {fileID: 8522799911296395315}
   - component: {fileID: 8522799911296395312}
-  m_Layer: 7
-  m_Name: Hitbox
+  m_Layer: 11
+  m_Name: PossessionHitbox
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -144,7 +591,7 @@ Transform:
   m_GameObject: {fileID: 8522799911296395319}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1.5, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_LocalScale: {x: 4, y: 3, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8522799911517438544}
@@ -330,6 +777,7 @@ Transform:
   - {fileID: 2008288455391228596}
   - {fileID: 7858299215221258208}
   - {fileID: 614040708023159319}
+  - {fileID: 1715315432}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/MAIN_LEVELS/Lab-2_BOSS.unity
+++ b/Assets/Scenes/MAIN_LEVELS/Lab-2_BOSS.unity
@@ -426,6 +426,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1504192467}
     m_Modifications:
+    - target: {fileID: 131025751533240346, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 131025753192615389, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
       propertyPath: m_RootOrder
       value: 12
@@ -473,6 +477,10 @@ PrefabInstance:
     - target: {fileID: 131025753192615390, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
       propertyPath: m_Name
       value: ThinPlatformXS (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 131025753192615390, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
@@ -17801,7 +17809,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 201b75e0ce83d46a096d994c054b8a2d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  timeToTween: 5
+  timeToTween: 3
   targetObject: {fileID: 1553340598}
 --- !u!1 &1010272669
 GameObject:
@@ -18512,7 +18520,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 131025753192615389, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -491.18
+      value: -492.51
       objectReference: {fileID: 0}
     - target: {fileID: 131025753192615389, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
       propertyPath: m_LocalPosition.z
@@ -52530,6 +52538,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1504192467}
     m_Modifications:
+    - target: {fileID: 131025751533240346, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 131025753192615389, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
       propertyPath: m_RootOrder
       value: 11
@@ -52577,6 +52589,10 @@ PrefabInstance:
     - target: {fileID: 131025753192615390, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
       propertyPath: m_Name
       value: ThinPlatformXS (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 131025753192615390, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
@@ -127286,7 +127302,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 131025753192615389, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -491.18
+      value: -492.51
       objectReference: {fileID: 0}
     - target: {fileID: 131025753192615389, guid: e9a8e75acb91a451aa9cbb907d671da8, type: 3}
       propertyPath: m_LocalPosition.z
@@ -127547,7 +127563,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 201b75e0ce83d46a096d994c054b8a2d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  timeToTween: 5
+  timeToTween: 3
   targetObject: {fileID: 1587850260}
 --- !u!1 &1955268430
 GameObject:

--- a/Assets/Scenes/MechBossTest.unity
+++ b/Assets/Scenes/MechBossTest.unity
@@ -1143,7 +1143,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4441797537648031110, guid: 374f0f11b8bcc934e9e5cac63b762892, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7242271439264065129, guid: 374f0f11b8bcc934e9e5cac63b762892, type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 374f0f11b8bcc934e9e5cac63b762892, type: 3}
@@ -3921,6 +3925,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5ffaae510d1e741308e5c1ccbbaf8a8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isPlayerPossessing: {fileID: 0}
 --- !u!95 &1099828562
 Animator:
   serializedVersion: 5
@@ -3954,6 +3959,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerPrefab: {fileID: 7897570920410490818, guid: a658cfb54edf871488fa26948c32ae90, type: 3}
+  enableOnPossessionContainer: {fileID: 0}
   unpossessionSpawnPoint: {fileID: 2015183447}
   isPlayerPossessing: {fileID: 11400000, guid: cf0648d02273744cca9a37866585f057, type: 2}
   slimePossessionSpriteRenderer: {fileID: 0}
@@ -11907,6 +11913,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4664956826829216410, guid: 1a9131e66d4016d479f9b23fc1cfcbac, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6680975513234232504, guid: 1a9131e66d4016d479f9b23fc1cfcbac, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -11938,7 +11948,12 @@ MonoBehaviour:
   animator: {fileID: 4664956828325691069}
   enemyAI: {fileID: 4664956828325691066}
   body: {fileID: 4664956828325691083}
+  possessionManager: {fileID: 0}
+  move: {fileID: 0}
+  jump: {fileID: 0}
+  attack: {fileID: 0}
   chargeTime: 2
+  napTime: 4
 --- !u!114 &4664956828325691066 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4664956826829216410, guid: 1a9131e66d4016d479f9b23fc1cfcbac, type: 3}

--- a/Assets/ScriptableObjects/Attacks/CatMeleeAttack.asset
+++ b/Assets/ScriptableObjects/Attacks/CatMeleeAttack.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   description: 
   animationName: MeleeAttack
   damage: 2
-  duration: 0.7
+  duration: 1
   attackSoundEffect: {fileID: 0}
   attackType: 0
   knockback: 1

--- a/Assets/ScriptableObjects/Attacks/CatMeleeAttackPossessed.asset
+++ b/Assets/ScriptableObjects/Attacks/CatMeleeAttackPossessed.asset
@@ -10,19 +10,19 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6caa88c8e4eb5a046a58d73884644334, type: 3}
-  m_Name: SpiderEnemyProjectile
+  m_Name: CatMeleeAttackPossessed
   m_EditorClassIdentifier: 
   name: 
   description: 
-  animationName: ProjectileAttack
-  damage: 1
-  duration: 2
+  animationName: MeleeAttack
+  damage: 2
+  duration: 0.4
   attackSoundEffect: {fileID: 0}
-  attackType: 1
-  knockback: 0
-  knockbackForce: 0
-  projectilePrefab: {fileID: 8368949391819313113, guid: 08d4fa3cc6fef2643a728ee1fcf45aeb, type: 3}
-  projectileSpeed: 10
-  projectileRange: 10
-  destroyProjectileOnHit: 1
+  attackType: 0
+  knockback: 1
+  knockbackForce: 1
+  projectilePrefab: {fileID: 0}
+  projectileSpeed: 0
+  projectileRange: 0
+  destroyProjectileOnHit: 0
   willPossessTarget: 0

--- a/Assets/ScriptableObjects/Attacks/CatMeleeAttackPossessed.asset.meta
+++ b/Assets/ScriptableObjects/Attacks/CatMeleeAttackPossessed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 075898bc2c3a7d34bbb1440cb8caf9f7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Attacks/ExplosionAttack.asset
+++ b/Assets/ScriptableObjects/Attacks/ExplosionAttack.asset
@@ -15,12 +15,12 @@ MonoBehaviour:
   name: Splosion
   description: Splodey
   animationName: 
-  damage: 6
+  damage: 1
   duration: 0
   attackSoundEffect: {fileID: 0}
   attackType: 0
   knockback: 1
-  knockbackForce: 35
+  knockbackForce: 10
   projectilePrefab: {fileID: 0}
   projectileSpeed: 0
   projectileRange: 0

--- a/Assets/ScriptableObjects/Attacks/RatMeleeAttack.asset
+++ b/Assets/ScriptableObjects/Attacks/RatMeleeAttack.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   description: 
   animationName: MeleeAttack
   damage: 1
-  duration: 0.3
+  duration: 1
   attackSoundEffect: {fileID: 0}
   attackType: 0
   knockback: 1

--- a/Assets/ScriptableObjects/Attacks/RatMeleeAttackPossessed.asset
+++ b/Assets/ScriptableObjects/Attacks/RatMeleeAttackPossessed.asset
@@ -10,19 +10,19 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6caa88c8e4eb5a046a58d73884644334, type: 3}
-  m_Name: SpiderEnemyProjectile
+  m_Name: RatMeleeAttackPossessed
   m_EditorClassIdentifier: 
   name: 
   description: 
-  animationName: ProjectileAttack
+  animationName: MeleeAttack
   damage: 1
-  duration: 2
+  duration: 0.1
   attackSoundEffect: {fileID: 0}
-  attackType: 1
-  knockback: 0
-  knockbackForce: 0
-  projectilePrefab: {fileID: 8368949391819313113, guid: 08d4fa3cc6fef2643a728ee1fcf45aeb, type: 3}
-  projectileSpeed: 10
-  projectileRange: 10
-  destroyProjectileOnHit: 1
+  attackType: 0
+  knockback: 1
+  knockbackForce: 1
+  projectilePrefab: {fileID: 0}
+  projectileSpeed: 0
+  projectileRange: 0
+  destroyProjectileOnHit: 0
   willPossessTarget: 0

--- a/Assets/ScriptableObjects/Attacks/RatMeleeAttackPossessed.asset.meta
+++ b/Assets/ScriptableObjects/Attacks/RatMeleeAttackPossessed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cc4a4ac7f5b2b724cb4f5b90a8b1007f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Attacks/SpiderEnemyFire.asset
+++ b/Assets/ScriptableObjects/Attacks/SpiderEnemyFire.asset
@@ -16,11 +16,11 @@ MonoBehaviour:
   description: 
   animationName: ProjectileAttack
   damage: 1
-  duration: 2
+  duration: 0.5
   attackSoundEffect: {fileID: 0}
   attackType: 1
   knockback: 1
-  knockbackForce: 20
+  knockbackForce: -10
   projectilePrefab: {fileID: 8368949391819313113, guid: 08d4fa3cc6fef2643a728ee1fcf45aeb, type: 3}
   projectileSpeed: 0.05
   projectileRange: 0.1

--- a/Assets/ScriptableObjects/Attacks/SpiderEnemyProjectilePossessed.asset
+++ b/Assets/ScriptableObjects/Attacks/SpiderEnemyProjectilePossessed.asset
@@ -10,13 +10,13 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6caa88c8e4eb5a046a58d73884644334, type: 3}
-  m_Name: SpiderEnemyProjectile
+  m_Name: SpiderEnemyProjectilePossessed
   m_EditorClassIdentifier: 
   name: 
   description: 
   animationName: ProjectileAttack
   damage: 1
-  duration: 2
+  duration: 0.5
   attackSoundEffect: {fileID: 0}
   attackType: 1
   knockback: 0

--- a/Assets/ScriptableObjects/Attacks/SpiderEnemyProjectilePossessed.asset.meta
+++ b/Assets/ScriptableObjects/Attacks/SpiderEnemyProjectilePossessed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4e96350ee628e147960cdead7503b1c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Bosses/MechBossAI.cs
+++ b/Assets/Scripts/Bosses/MechBossAI.cs
@@ -106,11 +106,20 @@ public class MechBossAI : MonoBehaviour
                 animator.SetTrigger(Constants.PROJECTILE_ATTACK_ANIMATION);
             }
         }
-        else if (distanceToPlayer < meleeRange && Time.time >= nextMeleeTime && !isFiringProjectile)
+        else if (distanceToPlayer < meleeRange && Time.time >= nextMeleeTime && !isStomping && !isFiringProjectile)
         {
             FacePlayer();
-            nextMeleeTime = Time.time + stompData.duration;
-            animator.SetTrigger(Constants.MELEE_ATTACK_ANIMATION);
+            if (Time.time >= nextProjectileTime)
+            {
+                nextProjectileTime = Time.time + missileData.duration;
+                animator.SetTrigger(Constants.PROJECTILE_ATTACK_ANIMATION);
+            }
+            else
+            {
+                nextMeleeTime = Time.time + stompData.duration;
+                animator.SetTrigger(Constants.MELEE_ATTACK_ANIMATION);
+            }
+
         }
     }
 

--- a/Assets/Scripts/Bosses/MechBossMissileMotion.cs
+++ b/Assets/Scripts/Bosses/MechBossMissileMotion.cs
@@ -20,9 +20,10 @@ public class MechBossMissileMotion : MonoBehaviour
     [SerializeField] LayerMask detonationLayerMask;
     [SerializeField] Vector3 explosionOffset;
 
-    GameObject player;
+    [SerializeField] GameObject player;
     float spawnTime;
-    Vector3 playerLocationAtSpawn;
+    Vector3 spawnLocation;
+    [SerializeField] Vector3 playerLocationAtSpawn;
     bool isFalling = false;
     float horizontalOffset;
 
@@ -30,6 +31,7 @@ public class MechBossMissileMotion : MonoBehaviour
     {
         rb.velocity = new Vector3(0, riseVelocity , 0);
         spawnTime = Time.time;
+        spawnLocation = transform.position;
         player = GameObject.FindWithTag(Constants.PLAYER_TAG);
         playerLocationAtSpawn = player.transform.position;
     }
@@ -53,7 +55,7 @@ public class MechBossMissileMotion : MonoBehaviour
     {
         if (!isFalling && Time.time - spawnTime >= riseTime)
         {
-            transform.position = new Vector3(playerLocationAtSpawn.x + horizontalOffset, fallHeight, transform.position.z);
+            transform.position = new Vector3(playerLocationAtSpawn.x + horizontalOffset, spawnLocation.y + fallHeight, transform.position.z);
             Vector3 localScale = transform.localScale;
 		    localScale.y *= -1;
 		    transform.localScale = localScale;

--- a/Assets/Scripts/Combat/PossessionIndicator.cs
+++ b/Assets/Scripts/Combat/PossessionIndicator.cs
@@ -1,0 +1,88 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PossessionIndicator : MonoBehaviour
+{
+    [SerializeField] GameObject indicatorLine;
+    [SerializeField] Transform lineStartPoint;
+    [SerializeField] Transform lineEndPoint;
+    [SerializeField] PlayerMovementController playerMovement;
+
+    List<GameObject> enemiesInRange = new List<GameObject>();
+    GameObject closestEnemy;
+    GameObject previousClosestEnemy;
+    PossessionManager targetPossessionManager;
+    float minimumDistanceToPlayer;
+    float distanceToPlayer;
+    Vector3 playerDirection;
+    Vector3 playerPosition;
+    Vector3 enemyPosition;
+
+    void Update()
+    {
+        minimumDistanceToPlayer = 100f;
+
+        if(enemiesInRange.Count == 0)
+        {
+            indicatorLine.SetActive(false);
+            return;
+        }
+
+        playerPosition = transform.position;
+
+        foreach (GameObject enemy in enemiesInRange)
+        {
+            enemyPosition = enemy.transform.position;
+            distanceToPlayer = Vector3.Distance(playerPosition, enemyPosition);
+            if (distanceToPlayer < minimumDistanceToPlayer)
+            {
+                minimumDistanceToPlayer = distanceToPlayer;
+                previousClosestEnemy = closestEnemy;
+                closestEnemy = enemy;
+                UpdateLine();
+                if(previousClosestEnemy != null && closestEnemy != previousClosestEnemy)
+                {
+                    previousClosestEnemy.GetComponent<PossessionManager>().SetClosestToPlayer(false);
+                }
+                closestEnemy.GetComponent<PossessionManager>().SetClosestToPlayer(true);
+            }
+        }
+    }
+
+    void OnTriggerEnter2D(Collider2D other)
+    {
+        targetPossessionManager = other.GetComponent<PossessionManager>();
+        if (targetPossessionManager != null && targetPossessionManager.canGetPossessed)
+        {
+            enemiesInRange.Add(other.gameObject);
+        }
+    }
+
+    void OnTriggerExit2D(Collider2D other)
+    {
+        if(enemiesInRange.Contains(other.gameObject))
+        {
+            enemiesInRange.Remove(other.gameObject);
+        }
+    }
+
+    void UpdateLine()
+    {
+        indicatorLine.SetActive(true);
+        Vector3 localScale = indicatorLine.transform.localScale;
+        float lineLength = Vector3.Distance(lineStartPoint.position, lineEndPoint.position);
+		localScale.x *= minimumDistanceToPlayer/lineLength;
+        indicatorLine.transform.localScale = localScale;
+        if (playerMovement.IsFacingRight())
+        {
+            playerDirection = Vector3.right;
+        }
+        else
+        {
+            playerDirection = Vector3.left;
+        }
+        float angle = Vector3.SignedAngle(playerDirection, closestEnemy.transform.position - transform.position, Vector3.forward);
+        indicatorLine.transform.rotation = Quaternion.Euler(0, 0, angle);
+    }
+}

--- a/Assets/Scripts/Combat/PossessionIndicator.cs
+++ b/Assets/Scripts/Combat/PossessionIndicator.cs
@@ -33,6 +33,11 @@ public class PossessionIndicator : MonoBehaviour
 
         foreach (GameObject enemy in enemiesInRange)
         {
+            if (enemy == null)
+            {
+                enemiesInRange.Remove(enemy);
+                continue;
+            }
             enemyPosition = enemy.transform.position;
             distanceToPlayer = Vector3.Distance(playerPosition, enemyPosition);
             if (distanceToPlayer < minimumDistanceToPlayer)

--- a/Assets/Scripts/Combat/PossessionIndicator.cs.meta
+++ b/Assets/Scripts/Combat/PossessionIndicator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d1a896fd6e77b7478f07ff7bf997ec9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Combat/PossessionManager.cs
+++ b/Assets/Scripts/Combat/PossessionManager.cs
@@ -20,7 +20,8 @@ public class PossessionManager : MonoBehaviour
     [SerializeField] SlimePossessMotion slimePossessHurtPrefab;
     [SerializeField] SlimePossessMotion slimePossessPerilPrefab;
     [SerializeField] Transform slimeAttachPoint;
-    [SerializeField] bool canGetPossessed;
+    public bool canGetPossessed;
+    bool isClosestEnemyToPlayer = false;
     [Space]
     [Space]
     [SerializeField] Sound possessSound;
@@ -131,7 +132,7 @@ public class PossessionManager : MonoBehaviour
 
     public void GetPossessed(GameObject playerObj)
     {
-        if (isPlayerPossessing.value || !canGetPossessed) return;
+        if (isPlayerPossessing.value || !canGetPossessed || !isClosestEnemyToPlayer) return;
         if (possessSound != null) possessSound.Play();
         if (enableOnPossessionContainer != null) enableOnPossessionContainer.SetActive(true);
         SetEnemyComponentsEnabled(false);
@@ -253,5 +254,10 @@ public class PossessionManager : MonoBehaviour
     public bool IsPossessed()
     {
         return isPossessed;
+    }
+
+    public void SetClosestToPlayer(bool value)
+    {
+        isClosestEnemyToPlayer = value;
     }
 }

--- a/Assets/Scripts/Combat/PossessionManager.cs
+++ b/Assets/Scripts/Combat/PossessionManager.cs
@@ -38,6 +38,7 @@ public class PossessionManager : MonoBehaviour
     AIMovement aIMovement;
     BaseEnemyAI enemyAI;
     [SerializeField] ReflexJump reflexJump;
+    [SerializeField] Collider2D reflexJumpCollider;
 
     // player components - enabled while the enemy is being possessed
     PlayerMain playerMain;
@@ -190,6 +191,7 @@ public class PossessionManager : MonoBehaviour
         if (reflexJump != null)
         {
             reflexJump.enabled = value;
+            reflexJumpCollider.enabled = value;
         }
     }
 

--- a/Assets/Scripts/Enemies/SpiderFireHitboxSpawner.cs
+++ b/Assets/Scripts/Enemies/SpiderFireHitboxSpawner.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SpiderFireHitboxSpawner : MonoBehaviour
+{
+    [SerializeField] AttackData attackData;
+    [SerializeField] Hitbox hitboxPrefab;
+    
+    [SerializeField] PossessionManager sourcePossessionManager;
+    float hitboxSpawnTimer = 0f;
+
+    void Update()
+    {
+        hitboxSpawnTimer += Time.deltaTime;
+
+        if (hitboxSpawnTimer >= attackData.duration)
+        {
+            Instantiate(hitboxPrefab, transform.position, transform.rotation).SetPossessionManager(sourcePossessionManager);
+            hitboxSpawnTimer = 0f;
+        }
+    }
+
+    public void SetPossessionManager(PossessionManager possessionManager)
+    {
+        sourcePossessionManager = possessionManager;
+    }
+}

--- a/Assets/Scripts/Enemies/SpiderFireHitboxSpawner.cs.meta
+++ b/Assets/Scripts/Enemies/SpiderFireHitboxSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8ba5ecddd11aba449261c84bb496dce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemies/SpiderFireballHitbox.cs
+++ b/Assets/Scripts/Enemies/SpiderFireballHitbox.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class SpiderFireballHitbox : Hitbox
 {
-    [SerializeField] GameObject firePrefab;
+    [SerializeField] SpiderFireHitboxSpawner firePrefab;
     [SerializeField] Vector3 spawnAngle;
 
     void OnTriggerEnter2D(Collider2D other)
@@ -14,7 +14,7 @@ public class SpiderFireballHitbox : Hitbox
         if (other.CompareTag(Constants.ENEMY_TAG) && (!isEnemyHitbox || (isEnemyHitbox && sourcePossessionManager != null && sourcePossessionManager.IsPossessed())))
         {
             PlayHitSound();
-            Instantiate(firePrefab, transform.position, transform.rotation);
+            Instantiate(firePrefab, transform.position, transform.rotation).SetPossessionManager(sourcePossessionManager);
             Destroy(gameObject);
         }
 
@@ -24,7 +24,7 @@ public class SpiderFireballHitbox : Hitbox
         {
             other.GetComponent<PlayerCombat>().TakeDamage(attackData, transform.position);
             PlayHitSound();
-            Instantiate(firePrefab, transform.position, transform.rotation);
+            Instantiate(firePrefab, transform.position, transform.rotation).SetPossessionManager(sourcePossessionManager);
             Destroy(gameObject);
         }
     }

--- a/Assets/Scripts/Level/FloorMovement.cs
+++ b/Assets/Scripts/Level/FloorMovement.cs
@@ -13,8 +13,8 @@ public class FloorMovement : MonoBehaviour
     private Vector3 startPosition; 
 
     void OnEnable() {
-      this.startPosition = transform.position; 
-      this.gameObject.TweenPosition (targetObject.position, timeToTween).SetFrom (transform.position).SetPingPong ().SetInfinite();//.SetLoopCount(-1);//.SetOnComplete (SomeMethod);
+      this.startPosition = transform.position;
+      if (targetObject != null) this.gameObject.TweenPosition (targetObject.position, timeToTween).SetFrom (transform.position).SetPingPong ().SetInfinite();//.SetLoopCount(-1);//.SetOnComplete (SomeMethod);
     }
 
     void OnDisable() {

--- a/Assets/Scripts/Level/Hazard.cs
+++ b/Assets/Scripts/Level/Hazard.cs
@@ -20,7 +20,10 @@ public class Hazard : MonoBehaviour
 
     void OnTriggerEnter2D(Collider2D other)
     {
-        HandleCollision(other, -other.attachedRigidbody.velocity.normalized);
+        Vector2 collisionPoint = other.attachedRigidbody != null
+            ? -other.attachedRigidbody.velocity.normalized
+            : Vector2.zero;
+        HandleCollision(other, collisionPoint);
     }
 
     void OnTriggerStay2D(Collider2D other)
@@ -42,13 +45,13 @@ public class Hazard : MonoBehaviour
 
     void HandleCollision(Collider2D other, Vector2 collisionPoint)
     {
-        if (other.CompareTag(Constants.PLAYER_TAG))
+        if (other.CompareTag(Constants.PLAYER_TAG) && other.TryGetComponent<PlayerCombat>(out PlayerCombat playerCombat))
         {
-            other.GetComponent<PlayerCombat>().TakeDamage(attackData, collisionPoint);
+            playerCombat.TakeDamage(attackData, collisionPoint);
         }
-        if (other.CompareTag(Constants.ENEMY_TAG))
+        if (other.CompareTag(Constants.ENEMY_TAG) && other.TryGetComponent<BaseEnemyAI>(out BaseEnemyAI enemyAI))
         {
-            other.GetComponent<BaseEnemyAI>().TakeDamage(attackData, transform.position);
+            enemyAI.TakeDamage(attackData, transform.position);
         }
     }
 

--- a/Assets/Scripts/SceneManagement/Door.cs
+++ b/Assets/Scripts/SceneManagement/Door.cs
@@ -171,6 +171,7 @@ namespace DTDEV.SceneManagement
             PrepareRoomTransition();
             // move to top of hierarchy so DontDestroyOnLoad works
             transform.SetParent(null);
+            player.transform.SetParent(null);
             DontDestroyOnLoad(gameObject);
             DontDestroyOnLoad(player.gameObject);
             TransitionFader fader = FindObjectOfType<TransitionFader>();


### PR DESCRIPTION
-Updated boss missiles to fall from relative height above starting location instead of absolute
-Removed upper platforms from boss arena (they were blocking missiles)
-Lowered height of lower platforms in boss arena (to allow boss to hit platform with stomp attack)
-Increased movement speed of moving platforms in boss arena to prevent player from getting trapped
-Updated boss AI to use missiles in close range (this is to address cheese strategy of standing on top of boss and attacking until it dies)
-Reduced damage and knockback of missiles (getting hit by one would usually knock the player into another or into the spike pit, which seemed unfair, and the damage was previously high enough to kill the player in two hits)
-Significantly reduced attack speed of enemy rat (but left it high when possessed) -Increased attack speed of possessed (significantly) and unpossessed (slightly) spiders, and increased projectile speed for both
-Updated spider fire hitbox so that it can deal damage multiple times without requiring the target to leave the hitbox and reenter
-Reduced attack speed of enemy cat, and increased attack speed of possessed cat -Increased size of possession hitbox and added visual indicator for closest enemy that can be possessed (this also prevents multiple simultaneous possessions)